### PR TITLE
Unmock changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 JSON Schema $Ref Parser
 ============================
+
+_[json-schema-ref-parser](https://www.npmjs.com/package/json-schema-ref-parser) fork that excludes Node.js built-in modules in the browser._
+
 #### Parse, Resolve, and Dereference JSON Schema $ref pointers
 
 [![Build Status](https://api.travis-ci.com/APIDevTools/json-schema-ref-parser.svg?branch=master)](https://travis-ci.com/APIDevTools/json-schema-ref-parser)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,9 +24,10 @@ module.exports = karmaConfig({
   sourceDir: "lib",
   fixtures: "test/fixtures/**/*.js",
   browsers: {
-    ie: true,
+    ie: false,
+    safari: false
   },
   config: {
-    exclude,
+    exclude
   }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7706,8 +7706,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -9605,7 +9604,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -9614,8 +9612,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "json-schema-ref-parser",
-  "version": "7.1.2",
-  "description": "Parse, Resolve, and Dereference JSON Schema $ref pointers",
+  "name": "@meeshkanml/json-schema-ref-parser",
+  "version": "0.0.0",
+  "description": "json-schema-ref-parser fork excluding Node.js modules",
   "keywords": [
     "json",
     "schema",
@@ -22,10 +22,10 @@
       "email": "boris@performancejs.com"
     }
   ],
-  "homepage": "https://apitools.dev/json-schema-ref-parser/",
+  "homepage": "https://github.com/unmock/json-schema-ref-parser/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/APIDevTools/json-schema-ref-parser.git"
+    "url": "https://github.com/unmock/json-schema-ref-parser.git"
   },
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "browser": {
-    "fs": false
+    "fs": false,
+    "http": false,
+    "https": false
   },
   "files": [
     "lib"
@@ -70,6 +72,7 @@
   "dependencies": {
     "call-me-maybe": "^1.0.1",
     "js-yaml": "^3.13.1",
-    "ono": "^5.1.0"
+    "ono": "^5.1.0",
+    "url": "^0.11.0"
   }
 }


### PR DESCRIPTION
- This branch is published as [@meeshkanml/json-schema-ref-parser](https://www.npmjs.com/package/@meeshkanml/json-schema-ref-parser)
- Exclude Node.js packages in `browser` field
- Publish as `npm publish --access public [--dry-run]` (after bumping the version number in `package.json`)

 **DO NOT MERGE THIS BRANCH TO KEEP TRACK OF THE CHANGES WE'VE MADE, PLEASE** 😇